### PR TITLE
The new Raspberry Pi (Model B with 512MB RAM) changed some GPIO pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,10 +232,6 @@ That's it!
 
 ## Usage
 
-### .setPi(version)
-The new Raspberry Pi (Model B with 512MB RAM) changed some GPIO pins.
-If user pi-gpio for that, you should call this mathod at first, and give the argument ``512`` for it.
-
 ### .open(pinNumber, [direction = "output"], [callback])
 
 Aliased to ``.export``

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -32,6 +32,13 @@ var pinMapping2V512 = {
 	"13" : 27
 };
 
+var revision = fs.readFileSync('/proc/cpuinfo', 'utf-8').match(/Revision\t\:\s([\d\w]+)/);
+if(revision && parseInt(revision[1], 16) > 3){
+	for(var pin in pinMapping2V512){
+		pinMapping[pin] = pinMapping2V512[pin];
+	}
+}
+
 function isNumber(number) {
 	return !isNaN(parseInt(number, 10));
 }
@@ -125,14 +132,6 @@ var gpio = {
 		value = !!value?"1":"0";
 
 		fs.writeFile(sysFsPath + "/gpio" + pinMapping[pinNumber] + "/value", value, "utf8", callback);
-	},
-
-	setPi : function(version){
-		if(version == 512){
-			for(var pin in pinMapping2V512){
-				pinMapping[pin] = pinMapping2V512[pin];
-			}
-		}
 	}
 };
 


### PR DESCRIPTION
pi-gpio will not work well in the new RPi, I update the pins map object and had test it before ci.
you can diff the change in the code and README file. thx!
