### PR TITLE
Promises Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,22 @@
 pi-gpio
 =======
 
-pi-gpio is a simple node.js based library to help access the GPIO of the Raspberry Pi (Debian Wheezy). It's modelled loosely around the built-in ``fs`` module.
+pi-gpio is a simple Q promise-based node.js library to help access the GPIO of the Raspberry Pi (Debian Wheezy). It's modelled loosely around the built-in ``fs`` module.
 
 ```javascript
 var gpio = require("pi-gpio");
 
-gpio.open(16, "output", function(err) {		// Open pin 16 for output
-	gpio.write(16, 1, function() {			// Set pin 16 high (1)
-		gpio.close(16);						// Close pin 16
-	});
-});
+// Open pin 16 for output
+gpio.open(16, "output")
+  .then(function() {
+    return gpio.write(16, 1);
+  })
+  .then(function() {
+    return gpio.close(16);
+  })
+  .then(function() {
+    console.log('all done');
+  });
 ```
 
 ## How you can help
@@ -283,10 +289,14 @@ Reads the current value of the pin. Most useful if the pin is in the ``input`` d
 
 Example:
 ```javascript
-gpio.read(16, function(err, value) {
-	if(err) throw err;
-	console.log(value);	// The current state of the pin
-});
+gpio.read(16)
+  .then(function(value) {
+    // current state of the pin
+    console.log(value);
+  })
+  .fail(function(error) {
+    console.error('uh oh', JSON.stringify(error));
+  })
 ```
 
 ### .write(pinNumber, value, [callback])

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ pi-gpio
 
 pi-gpio is a simple Q promise-based node.js library to help access the GPIO of the Raspberry Pi (Debian Wheezy). It's modelled loosely around the built-in ``fs`` module.
 
+To learn more about promises:  https://github.com/kriskowal/q
+
 ```javascript
 var gpio = require("pi-gpio");
 

--- a/README.md
+++ b/README.md
@@ -246,7 +246,7 @@ That's it!
 
 ## Usage
 
-### .open(pinNumber, [options], [callback])
+### .open(pinNumber, [options])
 
 Aliased to ``.export``
 
@@ -254,38 +254,35 @@ Makes ``pinNumber`` available for use.
 
 * ``pinNumber``: The pin number to make available. Remember, ``pinNumber`` is the physical pin number on the Pi. 
 * ``options``: (Optional) Should be a string, such as ``input`` or ``input pullup``. You can specify whether the pin direction should be `input` or `output` (or `in` or `out`). You can additionally set the internal pullup / pulldown resistor by sepcifying `pullup` or `pulldown` (or `up` or `down`). If options isn't provided, it defaults to `output`. If a direction (`input` or `output`) is not specified (eg. only `up`), then the direction defaults to `output`.
-* ``callback``: (Optional) Will be called when the pin is available for use. May receive an error as the first argument if something went wrong.
 
-### .close(pinNumber, [callback])
+### .close(pinNumber)
 
 Aliased to ``.unexport``
 
 Closes ``pinNumber``.
 
 * ``pinNumber``: The pin number to close. Again, ``pinNumber`` is the physical pin number on the Pi.
-* ``callback``: (Optional) Will be called when the pin is closed. Again, may receive an error as the first argument.
 
-### .setDirection(pinNumber, direction, [callback])
+### .setDirection(pinNumber, direction)
 
 Changes the direction from ``input`` to ``output`` or vice-versa.
 
 * ``pinNumber``: As usual.
 * ``direction``: Either ``input`` or ``in`` or ``output`` or ``out``.
-* ``callback``: Will be called when direction change is complete. May receive an error as usual.
 
-### .getDirection(pinNumber, [callback])
+### .getDirection(pinNumber)
 
 Gets the direction of the pin. Acts like a getter for the method above.
 
 * ``pinNumber``: As usual
-* ``callback``: Will be called when the direction is received. The first argument could be an error. The second argument will either be ``in`` or ``out``. 
+* ``promise``: Will resolve to either ``in`` or ``out`` or rejected when the direction is received.
 
-### .read(pinNumber, [callback])
+### .read(pinNumber)
 
 Reads the current value of the pin. Most useful if the pin is in the ``input`` direction.
 
 * ``pinNumber``: As usual.
-* ``callback``: Will receive a possible error object as the first argument, and the value of the pin as the second argument. The value will be either ``0`` or ``1`` (numeric).
+* ``promise``: Will resolve to  either ``0`` or ``1`` (numeric).
 
 Example:
 ```javascript
@@ -299,13 +296,12 @@ gpio.read(16)
   })
 ```
 
-### .write(pinNumber, value, [callback])
+### .write(pinNumber, value)
 
 Writes ``value`` to ``pinNumber``. Will obviously fail if the pin is not in the ``output`` direction.
 
 * ``pinNumber``: As usual.
 * ``value``: Should be either a numeric ``0`` or ``1``. Any value that isn't ``0`` or ``1`` will be coerced to be boolean, and then converted to 0 (false) or 1 (true). Just stick to sending a numeric 0 or 1, will you? ;)
-* ``callback``: Will be called when the value is set. Again, might receive an error.
 
 ## Misc
 


### PR DESCRIPTION
I found that my project using pi-gpio cleaned up quite well with promises.  Here's a promise based flavor if interested.  

I think this could go even further, and benefit by a "Pin" object for usage like:

```
// gpio.open could create a "Pin" object (if a pinNumber is passed) and resolve
// with other gpio methods expecting a "Pin" object
gpio.open(16)
  .then(gpio.read)
  .then(function(pin) {
    console.log('pin value', pin.value);
    gpio.close(pin)
  })
```

Thanks!
