### PR TITLE
Switch to Wiring Pi GPIO utility

### DIFF
--- a/examples/blink.js
+++ b/examples/blink.js
@@ -1,0 +1,13 @@
+var gpio = require("../pi-gpio");
+
+// using relative import here for demo purposes
+// in your own projects, you should `npm install pi-gpio` and use:
+// var gpio = require("pi-gpio");
+
+var value = 1;
+    
+setInterval(function() {
+    gpio.write(16, value, function() {
+        value = (value === 1 ? 0 : 1);
+    });
+}, 1000);

--- a/examples/simple-rw.js
+++ b/examples/simple-rw.js
@@ -1,0 +1,16 @@
+var gpio = require("../pi-gpio");
+
+// using relative import here for demo purposes
+// in your own projects, you should `npm install pi-gpio` and use:
+// var gpio = require("pi-gpio");
+
+gpio.write(16, 1, function() {
+    console.log("Physical pin no. 16 set to high.");
+});
+
+// note that by default, the internal pullup/down resistors are off
+gpio.read(11, function(err, value) {
+    if (!err) {
+        console.log("Pin 11 is reading" + (value === 1 ? "high" : "low"));
+    }
+});

--- a/optionParser.js
+++ b/optionParser.js
@@ -1,0 +1,34 @@
+function parseOptions(string) {
+    var options = { 'direction': 'out' };
+    string.split(' ').filter(function noEmpties(t) {
+        return t;
+    }).forEach(function(option) {
+        switch (option.toLowerCase()) {
+            case 'in':
+            case 'input':
+                options.direction = 'in';
+                break;
+            case 'out':
+            case 'output':
+                options.direction = 'out';
+                break;
+            case 'up':
+            case 'pullup':
+                options.pull = 'up';
+                break;
+            case 'down':
+            case 'pulldown':
+                options.pull = 'down';
+                break;
+            case 'tri':
+                options.pull = 'tri';
+                break;
+            default:
+                throw new Error("Illegal option token!");
+                break;
+        }
+    });
+    return options;
+}
+
+exports.parse = parseOptions;

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Rakesh Pai <rakeshpai@gmail.com>",
   "name": "pi-gpio",
   "description": "A simple node.js-based GPIO helper for the Raspberry Pi",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "repository": {
     "type": "git",
     "url": "git@github.com:rakeshpai/pi-gpio.git"
@@ -19,7 +19,7 @@
     "simple"
   ],
   "dependencies": {
-    "pi-gpioUtil": "tjanson/pi-gpioUtil"
+    "pi-gpioutil": "^0.0.2"
   },
   "devDependencies": {
     "mocha": "1.x",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "gpio",
     "simple"
   ],
-  "dependencies": {},
+  "dependencies": {
+    "pi-gpioUtil": "tjanson/pi-gpioUtil"
+  },
   "devDependencies": {
     "mocha": "1.x",
     "should": "1.x"

--- a/paramParser.js
+++ b/paramParser.js
@@ -31,4 +31,24 @@ function parseOptions(string) {
     return options;
 }
 
-exports.parse = parseOptions;
+function parseValue(value) {
+    switch (value) {
+        case true:
+        case 1:
+        case '1':
+            return '1';
+            break;
+        case false:
+        case 0:
+        case '0':
+            return '0';
+            break;
+        default:
+            throw new Error('Illegal on/off value');
+            break;
+    }
+}
+
+exports.parseOptions = parseOptions;
+exports.parseValue   = parseValue;
+exports.parseDirection = function(dir) { return parseOptions(dir).direction; };

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -13,7 +13,7 @@ var parseOptions = require("./optionParser").parse;
 function noop(){};
 
 var gpio = {
-    read: function(physPin, callback, forceExport) {
+    read: function(physPin, callback, exportMode) {
         function readVal() {
             gpioUtil.read(physToWiring[physPin], function(err, stdout, stderr, boolVal) {
                 var intVal = boolVal ? 1 : 0;
@@ -21,12 +21,14 @@ var gpio = {
             });
         }
 
-        if (inputPins.indexOf(physPin) === -1 || forceExport) {
+        if ((inputPins.indexOf(physPin) === -1 && exportMode !== 'off') || exportMode === 'force') {
             gpioUtil.export(physToBcm[physPin], "in", function(err, stdout, stderr) {
                 if (!err) {
                     outputPins = outputPins.filter(function(e) { return e !== physPin; });
                     inputPins.push(physPin);
                     readVal();
+                } else {
+                    throw new Error(err);
                 }
             });
         } else {
@@ -34,8 +36,8 @@ var gpio = {
         }
     },
 
-    write: function(physPin, value, callback, forceExport) {
-        if (outputPins.indexOf(physPin) === -1 || forceExport) {
+    write: function(physPin, value, callback, exportMode) {
+        if ((outputPins.indexOf(physPin) === -1 && exportMode !== 'off') || exportMode === 'force') {
             gpioUtil.export(physToBcm[physPin], "out", function(err, stdout, stderr) {
                 if (!err) {
                     inputPins = inputPins.filter(function(e) { return e !== physPin; });

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -1,182 +1,110 @@
 "use strict";
-var fs = require("fs"),
-	path = require("path"),
-	exec = require("child_process").exec;
 
-var gpioAdmin = "gpio-admin",
-	sysFsPath = "/sys/devices/virtual/gpio";
+var gpioUtil = require("pi-gpioutil");
 
-var rev = fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
-	return line.indexOf("Revision") == 0;
-})[0].split(":")[1].trim();
+var physToBcm = require("./pinMap.js").physToBcm();
+var physToWiring = require("./pinMap.js").physToWiring;
 
-rev = parseInt(rev, 16) < 3 ? 1 : 2; // http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+var outputPins = [];
+var inputPins = [];
 
-var pinMapping = {
-	"3": 0,
-	"5": 1,
-	"7": 4,
-	"8": 14,
-	"10": 15,
-	"11": 17,
-	"12": 18,
-	"13": 21,
-	"15": 22,
-	"16": 23,
-	"18": 24,
-	"19": 10,
-	"21": 9,
-	"22": 25,
-	"23": 11,
-	"24": 8,
-	"26": 7,
+var parseOptions = require("./optionParser").parse;
 
-	// Model B+ pins
-	"29": 5,
-	"31": 6,
-	"32": 12,
-	"33": 13,
-	"35": 19,
-	"36": 16,
-	"37": 26,
-	"38": 20,
-	"40": 21
-};
-
-if(rev == 2) {
-	pinMapping["3"] = 2;
-	pinMapping["5"] = 3;
-	pinMapping["13"] = 27;
-}
-
-function isNumber(number) {
-	return !isNaN(parseInt(number, 10));
-}
-
-function noop(){}
-
-function handleExecResponse(method, pinNumber, callback) {
-	return function(err, stdout, stderr) {
-		if(err) {
-			console.error("Error when trying to", method, "pin", pinNumber);
-			console.error(stderr);
-			callback(err);
-		} else {
-			callback();
-		}
-	}
-}
-
-function sanitizePinNumber(pinNumber) {
-	if(!isNumber(pinNumber) || !isNumber(pinMapping[pinNumber])) {
-		throw new Error("Pin number isn't valid");
-	}
-
-	return parseInt(pinNumber, 10);
-}
-
-function sanitizeDirection(direction) {
-	direction = (direction || "").toLowerCase().trim();
-	if(direction === "in" || direction === "input") {
-		return "in";
-	} else if(direction === "out" || direction === "output" || !direction) {
-		return "out";
-	} else {
-		throw new Error("Direction must be 'input' or 'output'");
-	}
-}
-
-function sanitizeOptions(options) {
-	var sanitized = {};
-
-	options.split(" ").forEach(function(token) {
-		if(token == "in" || token == "input") {
-			sanitized.direction = "in";
-		}
-
-		if(token == "pullup" || token == "up") {
-			sanitized.pull = "pullup";
-		}
-
-		if(token == "pulldown" || token == "down") {
-			sanitized.pull = "pulldown";
-		}
-	});
-
-	if(!sanitized.direction) {
-		sanitized.direction = "out";
-	}
-
-	if(!sanitized.pull) {
-		sanitized.pull = "";
-	}
-
-	return sanitized;
-}
+function noop(){};
 
 var gpio = {
-	rev: rev,
-	
-	open: function(pinNumber, options, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
+    read: function(physPin, callback, forceExport) {
+        function readVal() {
+            gpioUtil.read(physToWiring[physPin], function(err, stdout, stderr, boolVal) {
+                var intVal = boolVal ? 1 : 0;
+                (callback || noop)(err, intVal);
+            });
+        }
 
-		if(!callback && typeof options === "function") {
-			callback = options;
-			options = "out";
-		}
+        if (inputPins.indexOf(physPin) === -1 || forceExport) {
+            gpioUtil.export(physToBcm[physPin], "in", function(err, stdout, stderr) {
+                if (!err) {
+                    outputPins = outputPins.filter(function(e) { return e !== physPin; });
+                    inputPins.push(physPin);
+                    readVal();
+                }
+            });
+        } else {
+            readVal();
+        }
+    },
 
-		options = sanitizeOptions(options);
+    write: function(physPin, value, callback, forceExport) {
+        if (outputPins.indexOf(physPin) === -1 || forceExport) {
+            gpioUtil.export(physToBcm[physPin], "out", function(err, stdout, stderr) {
+                if (!err) {
+                    inputPins = inputPins.filter(function(e) { return e !== physPin; });
+                    outputPins.push(physPin);
+                    gpioUtil.write(physToWiring[physPin], value, (callback || noop));
+                }
+            });
+        } else {
+            gpioUtil.write(physToWiring[physPin], value, function(err, stdout, stderr) {
+                (callback || noop)(err);
+            });
+        }
+    },
 
-		exec(gpioAdmin + " export " + pinMapping[pinNumber] + " " + options.pull, handleExecResponse("open", pinNumber, function(err) {
-			if(err) return (callback || noop)(err);
+    export: function(physPin, optionsString, callback) {
+        // allow option parameter to be omitted
+        if (typeof optionsString === 'function') {
+            callback = optionsString;
+            optionsString = '';
+        }
 
-			gpio.setDirection(pinNumber, options.direction, callback);
-		}));
-	},
+        var options = parseOptions(optionsString);
 
-	setDirection: function(pinNumber, direction, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
-		direction = sanitizeDirection(direction);
+        gpioUtil.export(physToBcm[physPin], options.direction, function(err, stdout, stderr) {
+            if (err) {
+                console.error("ERROR [pi-gpio] failed to export pin " + physPin);
+            }
+            if (options.direction === 'in') {
+                inputPins.push(physPin);
+            } else if (options.direction === 'out') {
+                outputPins.push(physPin);
+            }
 
-		fs.writeFile(sysFsPath + "/gpio" + pinMapping[pinNumber] + "/direction", direction, (callback || noop));
-	},
+            if (typeof options.pull !== 'undefined') {
+                gpioUtil.mode(physToWiring[physPin], options.pull, (callback || noop));
+            } else {
+                (callback || noop)(err);
+            }
+        });
+    },
 
-	getDirection: function(pinNumber, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
-		callback = callback || noop;
+    unexport: function(physPin, callback) {
+        gpioUtil.unexport(physToBcm[physPin], function(err, stdout, stderr) {
+            if (err) {
+                console.error("ERROR [pi-gpio] failed to unexport pin " + physPin);
+            }
+            inputPins = inputPins.filter(function(e) { return e !== physPin; });
+            outputPins = outputPins.filter(function(e) { return e !== physPin; });
+            (callback || noop)(err);
+        });
+    },
 
-		fs.readFile(sysFsPath + "/gpio" + pinMapping[pinNumber] + "/direction", "utf8", function(err, direction) {
-			if(err) return callback(err);
-			callback(null, sanitizeDirection(direction.trim()));
-		});
-	},
-
-	close: function(pinNumber, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
-
-		exec(gpioAdmin + " unexport " + pinMapping[pinNumber], handleExecResponse("close", pinNumber, callback || noop));
-	},
-
-	read: function(pinNumber, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
-
-		fs.readFile(sysFsPath + "/gpio" + pinMapping[pinNumber] + "/value", function(err, data) {
-			if(err) return (callback || noop)(err);
-
-			(callback || noop)(null, parseInt(data, 10));
-		});
-	},
-
-	write: function(pinNumber, value, callback) {
-		pinNumber = sanitizePinNumber(pinNumber);
-
-		value = !!value?"1":"0";
-
-		fs.writeFile(sysFsPath + "/gpio" + pinMapping[pinNumber] + "/value", value, "utf8", callback);
-	}
+    getMode: function(physPin, callback) {
+        gpioUtil.readall(function(err, stdout, stderr, pins) {
+            var relevantPin = pins.filter(function(pin) {
+                return pin.phys === physPin;
+            })[0];
+            (callback || noop)(err, relevantPin.mode);
+        });
+    }
 };
 
-gpio.export = gpio.open;
-gpio.unexport = gpio.close;
+// aliases
+gpio.open         = gpio.export;
+gpio.setDirection = gpio.export;
+gpio.close        = gpio.unexport;
+
+// note that mode is not quite the same as direction
+// mode can not only be 'in' or 'out', but also e.g. 'alt0'
+gpio.getDirection = gpio.getMode;
 
 module.exports = gpio;

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -2,7 +2,7 @@
 
 var gpioUtil = require("pi-gpioutil");
 
-var physToBcm = require("./pinMap.js").physToBcm();
+var physToBcm = require("./pinMap.js").physToBcm;
 var physToWiring = require("./pinMap.js").physToWiring;
 
 var outputPins = [];
@@ -15,14 +15,14 @@ function noop(){};
 var gpio = {
     read: function(physPin, callback, exportMode) {
         function readVal() {
-            gpioUtil.read(physToWiring[physPin], function(err, stdout, stderr, boolVal) {
+            gpioUtil.read(physToWiring(physPin), function(err, stdout, stderr, boolVal) {
                 var intVal = boolVal ? 1 : 0;
                 (callback || noop)(err, intVal);
             });
         }
 
         if ((inputPins.indexOf(physPin) === -1 && exportMode !== 'off') || exportMode === 'force') {
-            gpioUtil.export(physToBcm[physPin], "in", function(err, stdout, stderr) {
+            gpioUtil.export(physToBcm(physPin), "in", function(err, stdout, stderr) {
                 if (!err) {
                     outputPins = outputPins.filter(function(e) { return e !== physPin; });
                     inputPins.push(physPin);
@@ -38,15 +38,15 @@ var gpio = {
 
     write: function(physPin, value, callback, exportMode) {
         if ((outputPins.indexOf(physPin) === -1 && exportMode !== 'off') || exportMode === 'force') {
-            gpioUtil.export(physToBcm[physPin], "out", function(err, stdout, stderr) {
+            gpioUtil.export(physToBcm(physPin), "out", function(err, stdout, stderr) {
                 if (!err) {
                     inputPins = inputPins.filter(function(e) { return e !== physPin; });
                     outputPins.push(physPin);
-                    gpioUtil.write(physToWiring[physPin], value, (callback || noop));
+                    gpioUtil.write(physToWiring(physPin), value, (callback || noop));
                 }
             });
         } else {
-            gpioUtil.write(physToWiring[physPin], value, function(err, stdout, stderr) {
+            gpioUtil.write(physToWiring(physPin), value, function(err, stdout, stderr) {
                 (callback || noop)(err);
             });
         }
@@ -61,7 +61,7 @@ var gpio = {
 
         var options = parseOptions(optionsString);
 
-        gpioUtil.export(physToBcm[physPin], options.direction, function(err, stdout, stderr) {
+        gpioUtil.export(physToBcm(physPin), options.direction, function(err, stdout, stderr) {
             if (err) {
                 console.error("ERROR [pi-gpio] failed to export pin " + physPin);
             }
@@ -72,7 +72,7 @@ var gpio = {
             }
 
             if (typeof options.pull !== 'undefined') {
-                gpioUtil.mode(physToWiring[physPin], options.pull, (callback || noop));
+                gpioUtil.mode(physToWiring(physPin), options.pull, (callback || noop));
             } else {
                 (callback || noop)(err);
             }
@@ -80,7 +80,7 @@ var gpio = {
     },
 
     unexport: function(physPin, callback) {
-        gpioUtil.unexport(physToBcm[physPin], function(err, stdout, stderr) {
+        gpioUtil.unexport(physToBcm(physPin), function(err, stdout, stderr) {
             if (err) {
                 console.error("ERROR [pi-gpio] failed to unexport pin " + physPin);
             }

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -20,6 +20,11 @@ var gpio = {
     rev: revision,
 
     read: function(physPin, callback, exportMode) {
+        if (typeof callback === 'string') {
+            exportMode = callback;
+            callback = null;
+        }
+
         function readVal(err) {
             if (err) {
                 (callback || noop)(err);
@@ -39,6 +44,11 @@ var gpio = {
     },
 
     write: function(physPin, value, callback, exportMode) {
+        if (typeof callback === 'string') {
+            exportMode = callback;
+            callback = null;
+        }
+
         function writeVal(err) {
             if (err) {
                 (callback || noop)(err);

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -17,6 +17,8 @@ var sysFsPath = "/sys/devices/virtual/gpio";
 function noop(){};
 
 var gpio = {
+    rev: revision,
+
     read: function(physPin, callback, exportMode) {
         function readVal(err) {
             if (err) {

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -90,23 +90,21 @@ var gpio = {
         });
     },
 
-    getMode: function(physPin, callback) {
-        gpioUtil.readall(function(err, stdout, stderr, pins) {
-            var relevantPin = pins.filter(function(pin) {
-                return pin.phys === physPin;
-            })[0];
-            (callback || noop)(err, relevantPin.mode);
+    getDirection: function(physPin, callback) {
+        fs.readFile(sysFsPath + "/gpio" + physToBcm(physPin) + "/direction", "utf8", function(err, direction) {
+            if (err) return (callback || noop)(err);
+            (callback || noop)(null, direction.trim());
         });
+    },
+
+    setDirection: function(physPin, direction, callback) {
+        direction = parseDirection(direction);
+        fs.writeFile(sysFsPath + "/gpio" + physToBcm(physPin) + "/direction", direction, (callback || noop));
     }
 };
 
 // aliases
-gpio.open         = gpio.export;
-gpio.setDirection = gpio.export;
-gpio.close        = gpio.unexport;
-
-// note that mode is not quite the same as direction
-// mode can not only be 'in' or 'out', but also e.g. 'alt0'
-gpio.getDirection = gpio.getMode;
+gpio.open  = gpio.export;
+gpio.close = gpio.unexport;
 
 module.exports = gpio;

--- a/pi-gpio.js
+++ b/pi-gpio.js
@@ -1,15 +1,16 @@
 "use strict";
 
-var fs = require("fs");
-var gpioUtil = require("pi-gpioutil");
-
-var physToBcm = require("./pinMap.js").physToBcm;
-var physToWiring = require("./pinMap.js").physToWiring;
+var fs             = require("fs");
+var gpioUtil       = require("pi-gpioutil");
+var revision       = require("./piRevision");
+var physToBcm      = require("./pinMap").physToBcm;
+var physToWiring   = require("./pinMap").physToWiring;
+var parseOptions   = require("./paramParser").parseOptions;
+var parseValue     = require("./paramParser").parseValue;
+var parseDirection = require("./paramParser").parseDirection;
 
 var outputPins = [];
 var inputPins = [];
-
-var parseOptions = require("./optionParser").parse;
 
 var sysFsPath = "/sys/devices/virtual/gpio";
 
@@ -40,7 +41,7 @@ var gpio = {
             if (err) {
                 (callback || noop)(err);
             } else {
-                fs.writeFile(sysFsPath + "/gpio" + physToBcm(physPin) + "/value", value, "utf8", (callback || noop));
+                fs.writeFile(sysFsPath + "/gpio" + physToBcm(physPin) + "/value", parseValue(value), "utf8", (callback || noop));
             }
         }
 

--- a/piRevision.js
+++ b/piRevision.js
@@ -1,0 +1,8 @@
+var fs = require('fs');
+
+// http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+var rev = parseInt(fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
+              return line.indexOf("Revision") == 0;
+          })[0].split(":")[1].trim(), 16) < 3 ? 1 : 2;
+
+module.exports = rev;

--- a/pinMap.js
+++ b/pinMap.js
@@ -1,0 +1,80 @@
+var fs = require('fs');
+
+var rev = fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
+              return line.indexOf("Revision") == 0;
+          })[0].split(":")[1].trim();
+
+rev = parseInt(rev, 16) < 3 ? 1 : 2; // http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+
+const baseMap = {
+    "3": 0,
+    "5": 1,
+    "7": 4,
+    "8": 14,
+    "10": 15,
+    "11": 17,
+    "12": 18,
+    "13": 21,
+    "15": 22,
+    "16": 23,
+    "18": 24,
+    "19": 10,
+    "21": 9,
+    "22": 25,
+    "23": 11,
+    "24": 8,
+    "26": 7,
+
+    // Model B+ pins
+    "29": 5,
+    "31": 6,
+    "32": 12,
+    "33": 13,
+    "35": 19,
+    "36": 16,
+    "37": 26,
+    "38": 20,
+    "40": 21
+};
+
+var physToBcm = function() {
+    var map = JSON.parse(JSON.stringify(baseMap));
+    if (rev == 2) {
+        map["3"] = 2;
+        map["5"] = 3;
+        map["13"] = 27;
+    }
+    return map;
+}
+
+const physToWiring = {
+    "3": 8,
+    "5": 9,
+    "7": 7,
+    "8": 15,
+    "10": 16,
+    "11": 0,
+    "12": 1,
+    "13": 2,
+    "15": 3,
+    "16": 4,
+    "18": 5,
+    "19": 12,
+    "21": 13,
+    "22": 6,
+    "23": 14,
+    "24": 10,
+    "26": 11,
+    "29": 21,
+    "31": 22,
+    "32": 26,
+    "33": 23,
+    "35": 24,
+    "36": 27,
+    "37": 25,
+    "38": 28,
+    "40": 29
+}
+
+module.exports.physToBcm = physToBcm;
+module.exports.physToWiring = physToWiring;

--- a/pinMap.js
+++ b/pinMap.js
@@ -1,80 +1,62 @@
 var fs = require('fs');
 
-var rev = fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
+// http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+var rev = parseInt(fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
               return line.indexOf("Revision") == 0;
-          })[0].split(":")[1].trim();
+          })[0].split(":")[1].trim(), 16) < 3 ? 1 : 2;
 
-rev = parseInt(rev, 16) < 3 ? 1 : 2; // http://elinux.org/RPi_HardwareHistory#Board_Revision_History
+// physical pin to [bcm, wiring]
+const bcmIndex = 0;
+const wpiIndex = 1;
+const pinMap = {
+    "3": (rev === 2 ? [2, 8] : [0, 8]),
+    "5": (rev === 2 ? [5, 9] : [1, 9]),
+    "7": [4, 7],
+    "8": [14, 15],
+    "10": [15, 16],
+    "11": [17, 0],
+    "12": [18, 1],
+    "13": (rev === 2 ? [27, 2]: [21, 2]),
+    "15": [22, 3],
+    "16": [23, 4],
+    "18": [24, 5],
+    "19": [10, 12],
+    "21": [9,  13],
+    "22": [25, 6],
+    "23": [11, 14],
+    "24": [8,  10],
+    "26": [7,  11],
 
-const baseMap = {
-    "3": 0,
-    "5": 1,
-    "7": 4,
-    "8": 14,
-    "10": 15,
-    "11": 17,
-    "12": 18,
-    "13": 21,
-    "15": 22,
-    "16": 23,
-    "18": 24,
-    "19": 10,
-    "21": 9,
-    "22": 25,
-    "23": 11,
-    "24": 8,
-    "26": 7,
-
-    // Model B+ pins
-    "29": 5,
-    "31": 6,
-    "32": 12,
-    "33": 13,
-    "35": 19,
-    "36": 16,
-    "37": 26,
-    "38": 20,
-    "40": 21
+    // Model  B+ pins
+    "29": [5,  21],
+    "31": [6,  22],
+    "32": [12, 26],
+    "33": [13, 23],
+    "35": [19, 24],
+    "36": [16, 27],
+    "37": [26, 25],
+    "38": [20, 28],
+    "40": [21, 29]
 };
 
-var physToBcm = function() {
-    var map = JSON.parse(JSON.stringify(baseMap));
-    if (rev == 2) {
-        map["3"] = 2;
-        map["5"] = 3;
-        map["13"] = 27;
+function convert(pinNumber, mapIndex) {
+    pinNumber = parseInt(pinNumber, 10);
+    if (typeof pinNumber !== 'number') {
+        throw new Error("Pin number isn't valid [1]");
     }
-    return map;
+    if (typeof pinMap[pinNumber] !== 'object') {
+        throw new Error("Pin number isn't valid [2]");
+    }
+    if (typeof pinMap[pinNumber][mapIndex] !== 'number') {
+        throw new Error("Pin number isn't valid [3]");
+    }
+    return pinMap[pinNumber][mapIndex];
 }
 
-const physToWiring = {
-    "3": 8,
-    "5": 9,
-    "7": 7,
-    "8": 15,
-    "10": 16,
-    "11": 0,
-    "12": 1,
-    "13": 2,
-    "15": 3,
-    "16": 4,
-    "18": 5,
-    "19": 12,
-    "21": 13,
-    "22": 6,
-    "23": 14,
-    "24": 10,
-    "26": 11,
-    "29": 21,
-    "31": 22,
-    "32": 26,
-    "33": 23,
-    "35": 24,
-    "36": 27,
-    "37": 25,
-    "38": 28,
-    "40": 29
+module.exports.physToBcm = function(physPin) {
+    return convert(physPin, bcmIndex);
 }
 
-module.exports.physToBcm = physToBcm;
-module.exports.physToWiring = physToWiring;
+module.exports.physToWiring = function(physPin) {
+    return convert(physPin, wpiIndex);
+}

--- a/pinMap.js
+++ b/pinMap.js
@@ -1,9 +1,4 @@
-var fs = require('fs');
-
-// http://elinux.org/RPi_HardwareHistory#Board_Revision_History
-var rev = parseInt(fs.readFileSync("/proc/cpuinfo").toString().split("\n").filter(function(line) {
-              return line.indexOf("Revision") == 0;
-          })[0].split(":")[1].trim(), 16) < 3 ? 1 : 2;
+var rev = require('./piRevision');
 
 // physical pin to [bcm, wiring]
 const bcmIndex = 0;

--- a/test/pi-gpio.js
+++ b/test/pi-gpio.js
@@ -23,6 +23,12 @@ function verifyValue(value, done) {
 }
 
 describe("pi-gpio", function() {
+    describe(".rev", function() {
+        it("should be 1 or 2", function() {
+            gpio.rev.should.be.within(1, 2);
+        });
+    });
+
     describe("hooks", function() {
         before("close pin", function(done) {
             gpio.close(testPin, done);
@@ -116,7 +122,7 @@ describe("pi-gpio", function() {
     ["0", "1"].forEach(function(testValue) {
         describe("hooks", function() {
             before("set pin to: " + testValue, function(done) {
-                gpio.write(testPin, testValue, done, true); // force-export
+                gpio.write(testPin, testValue, done, 'force'); // force-export
             });
 
             describe(".read", function() {

--- a/test/pi-gpio.js
+++ b/test/pi-gpio.js
@@ -1,98 +1,137 @@
 var gpio = require("../pi-gpio"),
-	should = require("should"),
-	fs = require("fs");
+    should = require("should"),
+    fs = require("fs");
+
+var testPin = 16;
+var testPinSysPath = "/sys/devices/virtual/gpio/gpio23";
+var invalidPin = 1;
+
+function verifyByFsRead(file, expectedContent, done) {
+    fs.readFile(testPinSysPath + "/" + file, "utf8", function(err, data) {
+        should.not.exist(err);
+        data.trim().should.equal(expectedContent);
+        done();
+    });
+}
+
+function verifyDirection(direction, done) {
+    verifyByFsRead("direction", direction, done);
+}
+
+function verifyValue(value, done) {
+    verifyByFsRead("value", value, done);
+}
 
 describe("pi-gpio", function() {
-	describe(".open", function() {
-		it("should open without errors", function(done) {
-			gpio.open(16, "output", function(err) {
-				should.not.exist(err);
-				done();
-			});
-		});
+    describe("hooks", function() {
+        before("close pin", function(done) {
+            gpio.close(testPin, done);
+        });
 
-		it("should throw an error if the pin is invalid", function() {
-			try {
-				gpio.open(1);
-			} catch(e) {
-				e.should.exist;
-			}
-		});
+        describe(".open", function() {
+            it("should open without errors", function(done) {
+                gpio.open(testPin, function(err) {
+                    should.not.exist(err);
+                    done();
+                });
+            });
+    
+            it("should throw an error if the pin is invalid", function() {
+                try {
+                    gpio.open(invalidPin);
+                } catch(e) {
+                    e.should.exist;
+                }
+            });
+    
+            it("should set the direction to output by default", verifyDirection.bind(this, "out"));
+        });
+    });
 
-		it("should set the direction correctly", function(done) {
-			fs.readFile("/sys/devices/virtual/gpio/gpio23/direction", "utf8", function(err, data) {
-				should.not.exist(err);
-				data.trim().should.equal("out");
-				done();
-			});
-		});
-	});
+    describe("hooks", function() {
+        before("open pin", function(done) {
+            gpio.open(testPin, done);
+        });
 
-	describe(".close", function() {
-		it("should close an open pin", function(done) {
-			gpio.close(16, done);
-		});
-	});
+        describe(".close", function() {
+            it("should close an open pin", function(done) {
+                gpio.close(testPin, done); // TODO actually test for success
+            });
+        });
+    });
 
-	describe(".setDirection", function() {
-		it("should set the direction of the pin", function(done) {
-			gpio.open(16, function(err) {
-				should.not.exist(err);
+    describe(".setDirection", function() {
+        ["in", "out"].forEach(function(direction) {
+            it("should set the direction of the pin: " + direction, function(done) {
+                gpio.open(testPin, direction, function(err) {
+                    should.not.exist(err);
+                    verifyDirection(direction, done);
+                });
+            });
+        });
+    });
 
-				gpio.setDirection(16, "input", function(err) {
-					should.not.exist(err);
+    ["in", "out"].forEach(function(testDirection) {
+        describe("hooks", function() {
+            before("open pin as: " + testDirection, function(done) {
+                gpio.open(testPin, testDirection, done);
+            });
 
-					fs.readFile("/sys/devices/virtual/gpio/gpio23/direction", "utf8", function(err, data) {
-						should.not.exist(err);
-						data.trim().should.equal("in");
-						done();
-					});
-				});
-			});
-		});
-	});
+            describe(".getDirection", function() {
+                it("should get the direction of the pin: " + testDirection, function(done) {
+                    gpio.getDirection(testPin, function(err, direction) {
+                        should.not.exist(err);
+                        direction.should.equal(testDirection);
+                        done();
+                    });
+                });
+            });
+        });
+    });
 
-	describe(".getDirection", function() {
-		it("should get the direction of the pin", function(done) {
-			gpio.getDirection(16, function(err, direction) {
-				should.not.exist(err);
+    describe(".write", function() {
+        ["1", "0"].forEach(function(testValue) {
+            it("should write the value of the pin: " + testValue, function(done) {
+                gpio.open(testPin, "output", function(err) {
+                    should.not.exist(err);
+                    gpio.write(testPin, testValue, function(err) {
+                        should.not.exist(err);
+                        verifyValue(testValue, done);
+                    });
+                });
+            });
+    
+            it("should auto-export and write if pin closed: " + testValue, function(done) {
+                gpio.close(testPin, function(err) { /* sic! */
+                    should.not.exist(err);
+                    gpio.write(testPin, testValue, function(err) {
+                        should.not.exist(err);
+                        verifyValue(testValue, done);
+                    });
+                });
+            });
+        });
+    });
 
-				direction.should.equal("in");
-				done();
-			});
-		});
-	});
+    ["0", "1"].forEach(function(testValue) {
+        describe("hooks", function() {
+            before("set pin to: " + testValue, function(done) {
+                gpio.write(testPin, testValue, done, true); // force-export
+            });
 
-	describe(".write", function() {
-		it("should write the value of the pin", function(done) {
-			gpio.setDirection(16, "output", function(err) {
-				should.not.exist(err);
+            describe(".read", function() {
+                it("should read the value at the pin correctly: " + testValue, function(done) {
+                    gpio.read(testPin, function(err, value) {
+                        should.not.exist(err);
+                        value.should.equal(parseInt(testValue));
+                        done();
+                    }, 'off');
+                });
+            });
+        });
+    });
 
-				gpio.write(16, "1", function(err) {
-					should.not.exist(err);
-
-					fs.readFile("/sys/devices/virtual/gpio/gpio23/value", "utf8", function(err, data) {
-						should.not.exist(err);
-						data.trim().should.equal("1");
-						done();
-					});
-				});
-			});
-		});
-	});
-
-	describe(".read", function() {
-		it("should read the value at the pin correctly", function(done) {
-			gpio.read(16, function(err, value) {
-				should.not.exist(err);
-
-				value.should.equal(1);
-				done();
-			});
-		});
-	});
-
-	after(function(done) {
-		gpio.close(16, done);
-	});
+    after(function(done) {
+        gpio.close(testPin, done);
+    });
 });


### PR DESCRIPTION
- switched to GPIO utility (via tjanson/pi-gpioutil) (see #25)
- automatic export/direction change on read/write (see `exportMode` param)
- refactored pinMap, parameter parser, revision detection into separate modules
- readme updated; some examples; more tests
- (did _not_ switch to native bindings (#26), but stayed with fs calls for read/write/{g,s}etDirection)

Let me know if any changes are required. Also: This passes all tests and works for me, but should still be tested manually.
